### PR TITLE
Documentation - Fix typo in selectors.custom function parameters

### DIFF
--- a/docs/manual/chapters/guide/features.typ
+++ b/docs/manual/chapters/guide/features.typ
@@ -119,7 +119,7 @@ If you now want to to be able to use these custom chapters with @cmd:hydra, you 
   #import "@preview/hydra:{{VERSION}}": hydra, selectors
 
   #let chap = figure.where(kind: "chapter")
-  #let sect = selectors.custom(heading.where(level: 1), ancestor: chap)
+  #let sect = selectors.custom(heading.where(level: 1), ancestors: chap)
 
   // Display the chapter on the left and the section on the right.
   #set page(header: context if calc.odd(here().page()) {


### PR DESCRIPTION
In the documentation, the code example Listing 4 does not compile because of the omitted 's'.