### PR TITLE
core: Use `auto` on missing `top` or `y` key in margin dict 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Changed
 
 ## Fixed
+- Fixed panic in `get-top-margin` on Typst 0.15
 
 ---
 

--- a/src/core.typ
+++ b/src/core.typ
@@ -12,7 +12,7 @@
     } else if "y" in margin {
       margin.y
     } else {
-      panic(util.fmt("Margin did not contain `top` or `y` key: `{}`", margin))
+      auto
     }
   }
 

--- a/tests/core/get-rules/top-margin/test.typ
+++ b/tests/core/get-rules/top-margin/test.typ
@@ -3,6 +3,8 @@
 ///   smaller one.
 /// - Height and width being `auto` causes fallback to `A4` paper size for
 ///   margin calculation.
+/// - An explicit margin dictionary without `top` or `y` key must assume a top
+///   margin of `auto` instead of panicking.
 
 #import "/src/lib.typ": core, util
 
@@ -15,5 +17,9 @@
 })
 
 #page([], height: auto, width: auto, header: context {
+  assert.eq(core.get-top-margin(), (2.5 / 21) * 210.0mm)
+})
+
+#page([], margin: (x: 10mm), height: auto, width: auto, header: context {
   assert.eq(core.get-top-margin(), (2.5 / 21) * 210.0mm)
 })


### PR DESCRIPTION
See commit messages.