### PR TITLE
Address typst package check CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Changed
 - Added alt text to `README.md`
+- Added `CONTRIBUTING.md` to package distribution
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [unreleased](https://github.com/tingerrr/hydra/releases/tags/)
 
 ## Changed
+- Added alt text to `README.md`
 
 ## Fixed
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ your document only when it is needed.
 == Second Section
 #lorem(100)
 ```
-![thumbnail]
+![A Lorem Ipsum example document of four pages showing "1 Introduction" at the top of the first page, but no header. The second page shows "2 Content" followed by "2.1 First Section" at the top, again with no header. On the third page the header shows "2 Contet" on the right side despite "2.2 Second Section" at the top. The final page shows "2.2 Second Section" on the left side of the header. The example document shows of the starting page and book mode checks in action.][thumbnail]
 
 ## Documentation
 For a more in-depth description of hydra's functionality and the reference read its [manual].

--- a/typst.toml
+++ b/typst.toml
@@ -9,4 +9,4 @@ description = "Query and display headings in your documents and templates."
 categories = ["components", "scripting"]
 keywords = ["context", "chapter", "section", "heading"]
 license = "MIT"
-exclude = ["assets", "docs", "tests", "CONTRIBUTING.md", "Justfile"]
+exclude = ["assets", "docs", "tests", "Justfile"]


### PR DESCRIPTION
Unfortunately the 0.6.3 assets in `typst/packages` will be slightly different from those on the tag `v0.6.3` of this repo because I forgot to update the thumbnail and manual. And since the check there is not being run on this repo I forgot some other things I'm fixing here too.